### PR TITLE
Add notifications popup

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -1,0 +1,32 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.notifications {
+  width: 320px;
+  min-height: 60px;
+  marign: 0.5em 0;
+  font-size: 12px;
+}
+
+.notification {
+  display: block;
+  padding: 0.5em 1em;
+  text-decoration: none;
+}
+
+.notification:hover {
+  background-color: rgb(240, 240, 240);
+}
+
+.notification-username {
+  margin-right: 0.5em;
+  color: #222;
+}
+.notification-title {
+  color: #08c;
+}

--- a/css/popup.css
+++ b/css/popup.css
@@ -2,6 +2,12 @@
   box-sizing: border-box;
 }
 
+html,
+body {
+  min-height: 300px;
+  overflow: scroll;
+}
+
 body {
   margin: 0;
 }

--- a/css/popup.css
+++ b/css/popup.css
@@ -19,6 +19,10 @@ body {
   text-decoration: none;
 }
 
+.notification.unread {
+  background: #e0f5ff;
+}
+
 .notification:hover {
   background-color: rgb(240, 240, 240);
 }

--- a/css/popup.css
+++ b/css/popup.css
@@ -21,6 +21,7 @@ body {
 
 .notification.unread {
   background: #e0f5ff;
+  font-weight: bold;
 }
 
 .notification:hover {

--- a/js/popup.js
+++ b/js/popup.js
@@ -28,8 +28,10 @@ var appendUrl = function(discourseUrl, n) {
 };
 
 var template = function(n) {
+  var classes = 'notification js-notification-link';
+  if (!n.read) classes += ' unread';
   return [
-    '<a href="' + n.url + '" class="notification js-notification-link">',
+    '<a href="' + n.url + '" class="' + classes + '">',
       '<span class="notification-username">',
         n.data.display_username,
       '</span>',

--- a/js/popup.js
+++ b/js/popup.js
@@ -1,0 +1,70 @@
+
+var buildNotificationsUrl = function(discourseUrl) {
+  return [
+    discourseUrl,
+    ( discourseUrl[discourseUrl.length - 1] !== '/' ? '/' : '' ),
+    'notifications?',
+    'recent=true'
+  ].join('');
+};
+
+var getNotificaitons = function(discourseUrl) {
+
+  var url = buildNotificationsUrl(discourseUrl);
+  var options = {
+    credentials: 'include',
+    headers: {
+      'Accept': 'application/json'
+    },
+  };
+
+  return fetch(url, options)
+          .then(function(res) { return res.json(); });
+};
+
+var appendUrl = function(discourseUrl, n) {
+  n.url = discourseUrl + '/t/' + n.slug + '/' + n.topic_id + '/' + n.post_number;
+  return n;
+};
+
+var template = function(n) {
+  return [
+    '<a href="' + n.url + '" class="notification js-notification-link">',
+      '<span class="notification-username">',
+        n.data.display_username,
+      '</span>',
+      '<span class="notification-title">',
+        n.data.topic_title,
+      '</span>',
+    '</a>'
+  ].join('');
+};
+
+var initLinks = function() {
+  var links = document.querySelectorAll('a[href]');
+
+  [].forEach.call(links, function(link) {
+    link.addEventListener('click', function(e) {
+      e.preventDefault();
+
+      chrome.tabs.create({ url: e.currentTarget.href });
+
+    }, false);
+  });
+};
+
+chrome.storage.sync.get({ discourseUrl: '' }, function (items) {
+
+  var discourseUrl = items.discourseUrl;
+
+  getNotificaitons(discourseUrl).then(function(data) {
+
+      var html = data.notifications.map(appendUrl.bind(null, discourseUrl))
+                                   .map(template)
+                                   .join('');
+
+      document.querySelector('.js-notifications').innerHTML = html;
+      initLinks();
+    });
+
+});

--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,7 @@
         "default_icon": {
             "19": "img/logo_bn19.png",
             "38": "img/logo38.png"
-        }
+        },
+        "default_popup": "popup.html"
     }
 }

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Notifications</title>
+  <link rel="stylesheet" href="css/popup.css">
+  <script src="js/popup.js"></script>
+</head>
+<body>
+  <div class="notifications js-notifications">
+    
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Hi @alepolidori!
Since I often go right to my notifications on discourse right after clicking the extensions icon, I thought, maybe we could load them in directly and skip a step. This is a bit unfinished, but was curious what you thought!

Left to complete:
- [x] Make unread notifications bold
- [x] Fix issue with pop showing up as different heights
- [x] Add icons for @-mention, reply, etc similar to Discourse menu

Screenshot:
![screenshot 2015-06-16 18 31 26](https://cloud.githubusercontent.com/assets/1509457/8196178/02bb1a62-1457-11e5-86f5-d8efa6f8364a.png)
